### PR TITLE
fix: React Router Doc is Broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This project aims to collect the **best free resources** for those that want to 
 1. [Exploring ES2016 and ES2017](https://leanpub.com/exploring-es2016-es2017/read) `advanced`
 
 ### Routing
-1. [React Router Docs](https://react-router.now.sh/) `basic`
+1. [React Router Docs](https://reactrouter.com/web/guides/quick-start) `basic`
 
 ### State Management
 #### [Redux](http://redux.js.org/)


### PR DESCRIPTION
I fixed the issue react router doc bronken link, adding the react router documentation fix #11 
https://reactrouter.com/web/guides/quick-start